### PR TITLE
Fix Aegis128LMac alignment

### DIFF
--- a/src/c/aegis128l.rs
+++ b/src/c/aegis128l.rs
@@ -223,18 +223,17 @@ impl<const TAG_BYTES: usize> Aegis128L<TAG_BYTES> {
 /// Note that AEGIS is not a hash function. It is a MAC that requires a secret key.
 /// Inputs leading to a state collision can be efficiently computed if the key is known.
 #[derive(Debug)]
+#[repr(align(32))]
 pub struct Aegis128LMac<const TAG_BYTES: usize> {
     st: aegis128l_state,
 }
 
 impl<const TAG_BYTES: usize> Clone for Aegis128LMac<TAG_BYTES> {
     fn clone(&self) -> Self {
-        let mut st = MaybeUninit::<aegis128l_state>::uninit();
+        let mut r = MaybeUninit::<Aegis128LMac<TAG_BYTES>>::uninit();
         unsafe {
-            aegis128l_mac_state_clone(st.as_mut_ptr(), &self.st);
-        }
-        Aegis128LMac {
-            st: unsafe { st.assume_init() },
+            aegis128l_mac_state_clone(r.as_mut_ptr() as *mut aegis128l_state, &self.st);
+            r.assume_init()
         }
     }
 }
@@ -274,12 +273,11 @@ impl<const TAG_BYTES: usize> Aegis128LMac<TAG_BYTES> {
             "Invalid tag length, must be 16 or 32"
         );
         Self::ensure_init();
-        let mut st = MaybeUninit::<aegis128l_state>::uninit();
+        let mut r: MaybeUninit<Aegis128LMac<TAG_BYTES>> =
+            MaybeUninit::<Aegis128LMac<TAG_BYTES>>::uninit();
         unsafe {
-            aegis128l_mac_init(st.as_mut_ptr(), key.as_ptr());
-        }
-        Aegis128LMac {
-            st: unsafe { st.assume_init() },
+            aegis128l_mac_init(r.as_mut_ptr() as *mut aegis128l_state, key.as_ptr());
+            r.assume_init()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ impl std::error::Error for Error {}
 #[cfg(test)]
 mod tests {
     use crate::aegis128l::Aegis128L;
+    #[cfg(feature = "std")]
+    use crate::aegis128l::Aegis128LMac;
     use crate::aegis256::Aegis256;
 
     #[test]
@@ -148,5 +150,19 @@ mod tests {
             .decrypt(&c, &tag, ad)
             .unwrap();
         assert_eq!(m2, m);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_aegis128l_mac() {
+        let s: Aegis128LMac<16> = Aegis128LMac::new(&[0; 16]);
+        let c = s.clone().finalize();
+
+        let expected_c = [
+            0x83, 0xCC, 0x60, 0x0D, 0xC4, 0xE3, 0xE7, 0xE6, 0x2D, 0x40, 0x55, 0x82, 0x61, 0x74,
+            0xF1, 0x49,
+        ];
+
+        assert_eq!(c, expected_c);
     }
 }


### PR DESCRIPTION
Libaegis aegis128l_mac* C functions expect the aegis128l_state data to be aligned to 32-bytes boundary.