### PR TITLE
Fix cross-compilation for Android (NDK toolchain)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,13 @@ fn has_clang() -> bool {
         .unwrap_or(false)
 }
 
+/// Returns true when host and target differ (cross-compilation).
+fn is_cross_compiling() -> bool {
+    let host = env::var("HOST").unwrap_or_default();
+    let target = env::var("TARGET").unwrap_or_default();
+    !host.is_empty() && !target.is_empty() && host != target
+}
+
 fn main() {
     let pure_rust = env::var("CARGO_FEATURE_PURE_RUST").is_ok();
     if pure_rust {
@@ -22,20 +29,28 @@ fn main() {
         return;
     }
     let mut build = cc::Build::new();
+    let cross = is_cross_compiling();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
     if target_env == "msvc" {
         // On MSVC targets, use the cc crate's proper API for preferring clang-cl.
         // Manually setting compiler("clang") on MSVC targets causes malformed
         // command lines (the -x flag is generated without its language argument).
         build.prefer_clang_cl_over_msvc(true);
-    } else if has_clang() {
+    } else if !cross && has_clang() {
+        // Only force host clang for native builds. When cross-compiling (e.g.
+        // for Android via NDK), let the `cc` crate auto-detect the correct
+        // toolchain from CC_<target> / CFLAGS_<target> environment variables.
         build.compiler("clang");
     }
     build
         .opt_level(3)
         .flag_if_supported("-Wno-unused-command-line-argument")
-        .flag_if_supported("-Wno-unknown-pragmas")
-        .flag_if_supported("-mtune=native")
+        .flag_if_supported("-Wno-unknown-pragmas");
+    if !cross {
+        // -mtune=native is only valid when compiling for the host architecture.
+        build.flag_if_supported("-mtune=native");
+    }
+    build
         .flag_if_supported("-mcrypto")
         .flag_if_supported("-mneon")
         .flag_if_supported("-maes")


### PR DESCRIPTION
## Problem

When cross-compiling for Android (e.g. `aarch64-linux-android`) from a macOS or Linux host, two things in `build.rs` break the build:

1. **`build.compiler("clang")`** is called unconditionally when the host has clang installed. This picks up the host's `/usr/bin/clang` instead of the NDK toolchain's clang. The `cc` crate normally auto-detects the correct cross-compiler from `CC_<target>` / `CFLAGS_<target>` environment variables (set by build systems like cargokit/ndk-build), but the explicit `compiler()` call overrides that detection.

2. **`-mtune=native`** is passed unconditionally, which is meaningless (and potentially harmful) when the target architecture differs from the host.

## Fix

Add an `is_cross_compiling()` helper that compares Cargo's `HOST` and `TARGET` environment variables, then:

- Only call `build.compiler("clang")` for native builds
- Only pass `-mtune=native` for native builds
- No change to MSVC behavior (`prefer_clang_cl_over_msvc` is unaffected)

Native builds behave identically to before. Cross-compilation now lets the `cc` crate do its job.

## Related

This PR also updates the `libaegis` submodule to include jedisct1/libaegis#34 (fix `HAVE_ANDROID_GETCPUFEATURES` for modern Android), which is needed to compile the C sources with current NDK versions.

## Tested

- `aarch64-linux-android` and `armv7-linux-androideabi` via Android NDK r27
- Cross-compiled from macOS (aarch64-apple-darwin host)
- Hardware-accelerated AEGIS (NEON AES) confirmed working on Android ARM64 devices — no fallback to software implementation
- Native macOS and iOS builds unaffected
