### PR TITLE
libaegis incremental update API

### DIFF
--- a/src/c/aegis128l.rs
+++ b/src/c/aegis128l.rs
@@ -62,6 +62,40 @@ extern "C" {
     fn aegis128l_mac_reset(st_: *mut aegis128l_mac_state);
 
     fn aegis128l_mac_state_clone(dst: *mut aegis128l_mac_state, src: *const aegis128l_mac_state);
+
+    fn aegis128l_state_init(
+        st_: *mut aegis128l_state,
+        ad: *const u8,
+        adlen: usize,
+        npub: *const u8,
+        k: *const u8,
+    );
+
+    fn aegis128l_state_encrypt_update(
+        st_: *mut aegis128l_state,
+        c: *mut u8,
+        m: *const u8,
+        mlen: usize,
+    ) -> c_int;
+
+    fn aegis128l_state_encrypt_final(
+        st_: *mut aegis128l_state,
+        mac: *mut u8,
+        maclen: usize,
+    ) -> c_int;
+
+    fn aegis128l_state_decrypt_update(
+        st_: *mut aegis128l_state,
+        m: *mut u8,
+        c: *const u8,
+        clen: usize,
+    ) -> c_int;
+
+    fn aegis128l_state_decrypt_final(
+        st_: *mut aegis128l_state,
+        mac: *const u8,
+        maclen: usize,
+    ) -> c_int;
 }
 
 #[cfg(feature = "std")]
@@ -364,5 +398,96 @@ impl<const TAG_BYTES: usize> Aegis128LMac<TAG_BYTES> {
         unsafe {
             aegis128l_mac_reset(&mut self.st);
         }
+    }
+}
+
+/// AEGIS-128L state for incremental encryption or decryption.
+#[derive(Debug)]
+pub struct Aegis128LState<const TAG_BYTES: usize> {
+    st: aegis128l_state,
+}
+
+impl<const TAG_BYTES: usize> Aegis128LState<TAG_BYTES> {
+    fn ensure_init() {
+        #[cfg(feature = "std")]
+        INIT.call_once(|| assert_eq!(unsafe { aegis_init() }, 0));
+
+        #[cfg(not(feature = "std"))]
+        {
+            use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+            if INITIALIZED.load(Acquire) {
+                return;
+            }
+            let initializing = match INITIALIZING.compare_exchange(false, true, Acquire, Relaxed) {
+                Ok(initializing) => initializing,
+                Err(initializing) => initializing,
+            };
+            if initializing {
+                while !INITIALIZED.load(Acquire) {}
+            } else {
+                assert_eq!(unsafe { aegis_init() }, 0);
+                INITIALIZED.store(true, Release);
+                INITIALIZING.store(false, Release);
+            }
+        }
+    }
+
+    /// Initializes the state for incremental encryption or decryption.
+    ///
+    /// # Panics
+    /// Panics if `TAG_BYTES` is not 16 or 32.
+    pub fn new(key: &Key, nonce: &Nonce, ad: &[u8]) -> Self {
+        assert!(
+            TAG_BYTES == 16 || TAG_BYTES == 32,
+            "Invalid tag length, must be 16 or 32"
+        );
+        Self::ensure_init();
+        let mut st = aegis128l_state { opaque: [0u8; 256] };
+        unsafe {
+            aegis128l_state_init(&mut st, ad.as_ptr(), ad.len(), nonce.as_ptr(), key.as_ptr());
+        }
+        Aegis128LState { st }
+    }
+
+    /// Encrypts a chunk. `c` must be at least `m.len()` bytes.
+    pub fn encrypt_update(&mut self, c: &mut [u8], m: &[u8]) -> Result<(), Error> {
+        if c.len() < m.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis128l_state_encrypt_update(&mut self.st, c.as_mut_ptr(), m.as_ptr(), m.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Finalizes encryption and returns the authentication tag.
+    pub fn encrypt_final(mut self) -> Tag<TAG_BYTES> {
+        let mut tag = [0u8; TAG_BYTES];
+        unsafe {
+            aegis128l_state_encrypt_final(&mut self.st, tag.as_mut_ptr(), TAG_BYTES);
+        }
+        tag
+    }
+
+    /// Decrypts a chunk. `m` must be at least `c.len()` bytes.
+    ///
+    /// The decrypted output must not be used until `decrypt_final` returns `Ok`.
+    pub fn decrypt_update(&mut self, m: &mut [u8], c: &[u8]) -> Result<(), Error> {
+        if m.len() < c.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis128l_state_decrypt_update(&mut self.st, m.as_mut_ptr(), c.as_ptr(), c.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Verifies the authentication tag and finalizes decryption.
+    pub fn decrypt_final(mut self, mac: &Tag<TAG_BYTES>) -> Result<(), Error> {
+        let ret = unsafe {
+            aegis128l_state_decrypt_final(&mut self.st, mac.as_ptr(), TAG_BYTES)
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
     }
 }

--- a/src/c/aegis128x2.rs
+++ b/src/c/aegis128x2.rs
@@ -67,6 +67,39 @@ extern "C" {
 
     fn aegis128x2_mac_state_clone(dst: *mut aegis128x2_mac_state, src: *const aegis128x2_mac_state);
 
+    fn aegis128x2_state_init(
+        st_: *mut aegis128x2_state,
+        ad: *const u8,
+        adlen: usize,
+        npub: *const u8,
+        k: *const u8,
+    );
+
+    fn aegis128x2_state_encrypt_update(
+        st_: *mut aegis128x2_state,
+        c: *mut u8,
+        m: *const u8,
+        mlen: usize,
+    ) -> c_int;
+
+    fn aegis128x2_state_encrypt_final(
+        st_: *mut aegis128x2_state,
+        mac: *mut u8,
+        maclen: usize,
+    ) -> c_int;
+
+    fn aegis128x2_state_decrypt_update(
+        st_: *mut aegis128x2_state,
+        m: *mut u8,
+        c: *const u8,
+        clen: usize,
+    ) -> c_int;
+
+    fn aegis128x2_state_decrypt_final(
+        st_: *mut aegis128x2_state,
+        mac: *const u8,
+        maclen: usize,
+    ) -> c_int;
 }
 
 #[cfg(feature = "std")]
@@ -369,5 +402,96 @@ impl<const TAG_BYTES: usize> Aegis128X2Mac<TAG_BYTES> {
         unsafe {
             aegis128x2_mac_reset(&mut self.st);
         }
+    }
+}
+
+/// AEGIS-128X2 state for incremental encryption or decryption.
+#[derive(Debug)]
+pub struct Aegis128X2State<const TAG_BYTES: usize> {
+    st: aegis128x2_state,
+}
+
+impl<const TAG_BYTES: usize> Aegis128X2State<TAG_BYTES> {
+    fn ensure_init() {
+        #[cfg(feature = "std")]
+        INIT.call_once(|| assert_eq!(unsafe { aegis_init() }, 0));
+
+        #[cfg(not(feature = "std"))]
+        {
+            use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+            if INITIALIZED.load(Acquire) {
+                return;
+            }
+            let initializing = match INITIALIZING.compare_exchange(false, true, Acquire, Relaxed) {
+                Ok(initializing) => initializing,
+                Err(initializing) => initializing,
+            };
+            if initializing {
+                while !INITIALIZED.load(Acquire) {}
+            } else {
+                assert_eq!(unsafe { aegis_init() }, 0);
+                INITIALIZED.store(true, Release);
+                INITIALIZING.store(false, Release);
+            }
+        }
+    }
+
+    /// Initializes the state for incremental encryption or decryption.
+    ///
+    /// # Panics
+    /// Panics if `TAG_BYTES` is not 16 or 32.
+    pub fn new(key: &Key, nonce: &Nonce, ad: &[u8]) -> Self {
+        assert!(
+            TAG_BYTES == 16 || TAG_BYTES == 32,
+            "Invalid tag length, must be 16 or 32"
+        );
+        Self::ensure_init();
+        let mut st = aegis128x2_state { opaque: [0u8; 448] };
+        unsafe {
+            aegis128x2_state_init(&mut st, ad.as_ptr(), ad.len(), nonce.as_ptr(), key.as_ptr());
+        }
+        Aegis128X2State { st }
+    }
+
+    /// Encrypts a chunk. `c` must be at least `m.len()` bytes.
+    pub fn encrypt_update(&mut self, c: &mut [u8], m: &[u8]) -> Result<(), Error> {
+        if c.len() < m.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis128x2_state_encrypt_update(&mut self.st, c.as_mut_ptr(), m.as_ptr(), m.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Finalizes encryption and returns the authentication tag.
+    pub fn encrypt_final(mut self) -> Tag<TAG_BYTES> {
+        let mut tag = [0u8; TAG_BYTES];
+        unsafe {
+            aegis128x2_state_encrypt_final(&mut self.st, tag.as_mut_ptr(), TAG_BYTES);
+        }
+        tag
+    }
+
+    /// Decrypts a chunk. `m` must be at least `c.len()` bytes.
+    ///
+    /// The decrypted output must not be used until `decrypt_final` returns `Ok`.
+    pub fn decrypt_update(&mut self, m: &mut [u8], c: &[u8]) -> Result<(), Error> {
+        if m.len() < c.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis128x2_state_decrypt_update(&mut self.st, m.as_mut_ptr(), c.as_ptr(), c.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Verifies the authentication tag and finalizes decryption.
+    pub fn decrypt_final(mut self, mac: &Tag<TAG_BYTES>) -> Result<(), Error> {
+        let ret = unsafe {
+            aegis128x2_state_decrypt_final(&mut self.st, mac.as_ptr(), TAG_BYTES)
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
     }
 }

--- a/src/c/aegis128x4.rs
+++ b/src/c/aegis128x4.rs
@@ -66,6 +66,40 @@ extern "C" {
     fn aegis128x4_mac_reset(st_: *mut aegis128x4_mac_state);
 
     fn aegis128x4_mac_state_clone(dst: *mut aegis128x4_mac_state, src: *const aegis128x4_mac_state);
+
+    fn aegis128x4_state_init(
+        st_: *mut aegis128x4_state,
+        ad: *const u8,
+        adlen: usize,
+        npub: *const u8,
+        k: *const u8,
+    );
+
+    fn aegis128x4_state_encrypt_update(
+        st_: *mut aegis128x4_state,
+        c: *mut u8,
+        m: *const u8,
+        mlen: usize,
+    ) -> c_int;
+
+    fn aegis128x4_state_encrypt_final(
+        st_: *mut aegis128x4_state,
+        mac: *mut u8,
+        maclen: usize,
+    ) -> c_int;
+
+    fn aegis128x4_state_decrypt_update(
+        st_: *mut aegis128x4_state,
+        m: *mut u8,
+        c: *const u8,
+        clen: usize,
+    ) -> c_int;
+
+    fn aegis128x4_state_decrypt_final(
+        st_: *mut aegis128x4_state,
+        mac: *const u8,
+        maclen: usize,
+    ) -> c_int;
 }
 
 #[cfg(feature = "std")]
@@ -368,5 +402,96 @@ impl<const TAG_BYTES: usize> Aegis128X4Mac<TAG_BYTES> {
         unsafe {
             aegis128x4_mac_reset(&mut self.st);
         }
+    }
+}
+
+/// AEGIS-128X4 state for incremental encryption or decryption.
+#[derive(Debug)]
+pub struct Aegis128X4State<const TAG_BYTES: usize> {
+    st: aegis128x4_state,
+}
+
+impl<const TAG_BYTES: usize> Aegis128X4State<TAG_BYTES> {
+    fn ensure_init() {
+        #[cfg(feature = "std")]
+        INIT.call_once(|| assert_eq!(unsafe { aegis_init() }, 0));
+
+        #[cfg(not(feature = "std"))]
+        {
+            use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+            if INITIALIZED.load(Acquire) {
+                return;
+            }
+            let initializing = match INITIALIZING.compare_exchange(false, true, Acquire, Relaxed) {
+                Ok(initializing) => initializing,
+                Err(initializing) => initializing,
+            };
+            if initializing {
+                while !INITIALIZED.load(Acquire) {}
+            } else {
+                assert_eq!(unsafe { aegis_init() }, 0);
+                INITIALIZED.store(true, Release);
+                INITIALIZING.store(false, Release);
+            }
+        }
+    }
+
+    /// Initializes the state for incremental encryption or decryption.
+    ///
+    /// # Panics
+    /// Panics if `TAG_BYTES` is not 16 or 32.
+    pub fn new(key: &Key, nonce: &Nonce, ad: &[u8]) -> Self {
+        assert!(
+            TAG_BYTES == 16 || TAG_BYTES == 32,
+            "Invalid tag length, must be 16 or 32"
+        );
+        Self::ensure_init();
+        let mut st = aegis128x4_state { opaque: [0u8; 832] };
+        unsafe {
+            aegis128x4_state_init(&mut st, ad.as_ptr(), ad.len(), nonce.as_ptr(), key.as_ptr());
+        }
+        Aegis128X4State { st }
+    }
+
+    /// Encrypts a chunk. `c` must be at least `m.len()` bytes.
+    pub fn encrypt_update(&mut self, c: &mut [u8], m: &[u8]) -> Result<(), Error> {
+        if c.len() < m.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis128x4_state_encrypt_update(&mut self.st, c.as_mut_ptr(), m.as_ptr(), m.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Finalizes encryption and returns the authentication tag.
+    pub fn encrypt_final(mut self) -> Tag<TAG_BYTES> {
+        let mut tag = [0u8; TAG_BYTES];
+        unsafe {
+            aegis128x4_state_encrypt_final(&mut self.st, tag.as_mut_ptr(), TAG_BYTES);
+        }
+        tag
+    }
+
+    /// Decrypts a chunk. `m` must be at least `c.len()` bytes.
+    ///
+    /// The decrypted output must not be used until `decrypt_final` returns `Ok`.
+    pub fn decrypt_update(&mut self, m: &mut [u8], c: &[u8]) -> Result<(), Error> {
+        if m.len() < c.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis128x4_state_decrypt_update(&mut self.st, m.as_mut_ptr(), c.as_ptr(), c.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Verifies the authentication tag and finalizes decryption.
+    pub fn decrypt_final(mut self, mac: &Tag<TAG_BYTES>) -> Result<(), Error> {
+        let ret = unsafe {
+            aegis128x4_state_decrypt_final(&mut self.st, mac.as_ptr(), TAG_BYTES)
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
     }
 }

--- a/src/c/aegis256.rs
+++ b/src/c/aegis256.rs
@@ -62,6 +62,40 @@ extern "C" {
     fn aegis256_mac_reset(st_: *mut aegis256_mac_state);
 
     fn aegis256_mac_state_clone(dst: *mut aegis256_mac_state, src: *const aegis256_mac_state);
+
+    fn aegis256_state_init(
+        st_: *mut aegis256_state,
+        ad: *const u8,
+        adlen: usize,
+        npub: *const u8,
+        k: *const u8,
+    );
+
+    fn aegis256_state_encrypt_update(
+        st_: *mut aegis256_state,
+        c: *mut u8,
+        m: *const u8,
+        mlen: usize,
+    ) -> c_int;
+
+    fn aegis256_state_encrypt_final(
+        st_: *mut aegis256_state,
+        mac: *mut u8,
+        maclen: usize,
+    ) -> c_int;
+
+    fn aegis256_state_decrypt_update(
+        st_: *mut aegis256_state,
+        m: *mut u8,
+        c: *const u8,
+        clen: usize,
+    ) -> c_int;
+
+    fn aegis256_state_decrypt_final(
+        st_: *mut aegis256_state,
+        mac: *const u8,
+        maclen: usize,
+    ) -> c_int;
 }
 
 #[cfg(feature = "std")]
@@ -364,5 +398,96 @@ impl<const TAG_BYTES: usize> Aegis256Mac<TAG_BYTES> {
         unsafe {
             aegis256_mac_reset(&mut self.st);
         }
+    }
+}
+
+/// AEGIS-256 state for incremental encryption or decryption.
+#[derive(Debug)]
+pub struct Aegis256State<const TAG_BYTES: usize> {
+    st: aegis256_state,
+}
+
+impl<const TAG_BYTES: usize> Aegis256State<TAG_BYTES> {
+    fn ensure_init() {
+        #[cfg(feature = "std")]
+        INIT.call_once(|| assert_eq!(unsafe { aegis_init() }, 0));
+
+        #[cfg(not(feature = "std"))]
+        {
+            use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+            if INITIALIZED.load(Acquire) {
+                return;
+            }
+            let initializing = match INITIALIZING.compare_exchange(false, true, Acquire, Relaxed) {
+                Ok(initializing) => initializing,
+                Err(initializing) => initializing,
+            };
+            if initializing {
+                while !INITIALIZED.load(Acquire) {}
+            } else {
+                assert_eq!(unsafe { aegis_init() }, 0);
+                INITIALIZED.store(true, Release);
+                INITIALIZING.store(false, Release);
+            }
+        }
+    }
+
+    /// Initializes the state for incremental encryption or decryption.
+    ///
+    /// # Panics
+    /// Panics if `TAG_BYTES` is not 16 or 32.
+    pub fn new(key: &Key, nonce: &Nonce, ad: &[u8]) -> Self {
+        assert!(
+            TAG_BYTES == 16 || TAG_BYTES == 32,
+            "Invalid tag length, must be 16 or 32"
+        );
+        Self::ensure_init();
+        let mut st = aegis256_state { opaque: [0u8; 192] };
+        unsafe {
+            aegis256_state_init(&mut st, ad.as_ptr(), ad.len(), nonce.as_ptr(), key.as_ptr());
+        }
+        Aegis256State { st }
+    }
+
+    /// Encrypts a chunk. `c` must be at least `m.len()` bytes.
+    pub fn encrypt_update(&mut self, c: &mut [u8], m: &[u8]) -> Result<(), Error> {
+        if c.len() < m.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis256_state_encrypt_update(&mut self.st, c.as_mut_ptr(), m.as_ptr(), m.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Finalizes encryption and returns the authentication tag.
+    pub fn encrypt_final(mut self) -> Tag<TAG_BYTES> {
+        let mut tag = [0u8; TAG_BYTES];
+        unsafe {
+            aegis256_state_encrypt_final(&mut self.st, tag.as_mut_ptr(), TAG_BYTES);
+        }
+        tag
+    }
+
+    /// Decrypts a chunk. `m` must be at least `c.len()` bytes.
+    ///
+    /// The decrypted output must not be used until `decrypt_final` returns `Ok`.
+    pub fn decrypt_update(&mut self, m: &mut [u8], c: &[u8]) -> Result<(), Error> {
+        if m.len() < c.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis256_state_decrypt_update(&mut self.st, m.as_mut_ptr(), c.as_ptr(), c.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Verifies the authentication tag and finalizes decryption.
+    pub fn decrypt_final(mut self, mac: &Tag<TAG_BYTES>) -> Result<(), Error> {
+        let ret = unsafe {
+            aegis256_state_decrypt_final(&mut self.st, mac.as_ptr(), TAG_BYTES)
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
     }
 }

--- a/src/c/aegis256x2.rs
+++ b/src/c/aegis256x2.rs
@@ -66,6 +66,40 @@ extern "C" {
     fn aegis256x2_mac_reset(st_: *mut aegis256x2_mac_state);
 
     fn aegis256x2_mac_state_clone(dst: *mut aegis256x2_mac_state, src: *const aegis256x2_mac_state);
+
+    fn aegis256x2_state_init(
+        st_: *mut aegis256x2_state,
+        ad: *const u8,
+        adlen: usize,
+        npub: *const u8,
+        k: *const u8,
+    );
+
+    fn aegis256x2_state_encrypt_update(
+        st_: *mut aegis256x2_state,
+        c: *mut u8,
+        m: *const u8,
+        mlen: usize,
+    ) -> c_int;
+
+    fn aegis256x2_state_encrypt_final(
+        st_: *mut aegis256x2_state,
+        mac: *mut u8,
+        maclen: usize,
+    ) -> c_int;
+
+    fn aegis256x2_state_decrypt_update(
+        st_: *mut aegis256x2_state,
+        m: *mut u8,
+        c: *const u8,
+        clen: usize,
+    ) -> c_int;
+
+    fn aegis256x2_state_decrypt_final(
+        st_: *mut aegis256x2_state,
+        mac: *const u8,
+        maclen: usize,
+    ) -> c_int;
 }
 
 #[cfg(feature = "std")]
@@ -368,5 +402,96 @@ impl<const TAG_BYTES: usize> Aegis256X2Mac<TAG_BYTES> {
         unsafe {
             aegis256x2_mac_reset(&mut self.st);
         }
+    }
+}
+
+/// AEGIS-256X2 state for incremental encryption or decryption.
+#[derive(Debug)]
+pub struct Aegis256X2State<const TAG_BYTES: usize> {
+    st: aegis256x2_state,
+}
+
+impl<const TAG_BYTES: usize> Aegis256X2State<TAG_BYTES> {
+    fn ensure_init() {
+        #[cfg(feature = "std")]
+        INIT.call_once(|| assert_eq!(unsafe { aegis_init() }, 0));
+
+        #[cfg(not(feature = "std"))]
+        {
+            use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+            if INITIALIZED.load(Acquire) {
+                return;
+            }
+            let initializing = match INITIALIZING.compare_exchange(false, true, Acquire, Relaxed) {
+                Ok(initializing) => initializing,
+                Err(initializing) => initializing,
+            };
+            if initializing {
+                while !INITIALIZED.load(Acquire) {}
+            } else {
+                assert_eq!(unsafe { aegis_init() }, 0);
+                INITIALIZED.store(true, Release);
+                INITIALIZING.store(false, Release);
+            }
+        }
+    }
+
+    /// Initializes the state for incremental encryption or decryption.
+    ///
+    /// # Panics
+    /// Panics if `TAG_BYTES` is not 16 or 32.
+    pub fn new(key: &Key, nonce: &Nonce, ad: &[u8]) -> Self {
+        assert!(
+            TAG_BYTES == 16 || TAG_BYTES == 32,
+            "Invalid tag length, must be 16 or 32"
+        );
+        Self::ensure_init();
+        let mut st = aegis256x2_state { opaque: [0u8; 320] };
+        unsafe {
+            aegis256x2_state_init(&mut st, ad.as_ptr(), ad.len(), nonce.as_ptr(), key.as_ptr());
+        }
+        Aegis256X2State { st }
+    }
+
+    /// Encrypts a chunk. `c` must be at least `m.len()` bytes.
+    pub fn encrypt_update(&mut self, c: &mut [u8], m: &[u8]) -> Result<(), Error> {
+        if c.len() < m.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis256x2_state_encrypt_update(&mut self.st, c.as_mut_ptr(), m.as_ptr(), m.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Finalizes encryption and returns the authentication tag.
+    pub fn encrypt_final(mut self) -> Tag<TAG_BYTES> {
+        let mut tag = [0u8; TAG_BYTES];
+        unsafe {
+            aegis256x2_state_encrypt_final(&mut self.st, tag.as_mut_ptr(), TAG_BYTES);
+        }
+        tag
+    }
+
+    /// Decrypts a chunk. `m` must be at least `c.len()` bytes.
+    ///
+    /// The decrypted output must not be used until `decrypt_final` returns `Ok`.
+    pub fn decrypt_update(&mut self, m: &mut [u8], c: &[u8]) -> Result<(), Error> {
+        if m.len() < c.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis256x2_state_decrypt_update(&mut self.st, m.as_mut_ptr(), c.as_ptr(), c.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Verifies the authentication tag and finalizes decryption.
+    pub fn decrypt_final(mut self, mac: &Tag<TAG_BYTES>) -> Result<(), Error> {
+        let ret = unsafe {
+            aegis256x2_state_decrypt_final(&mut self.st, mac.as_ptr(), TAG_BYTES)
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
     }
 }

--- a/src/c/aegis256x4.rs
+++ b/src/c/aegis256x4.rs
@@ -66,6 +66,40 @@ extern "C" {
     fn aegis256x4_mac_reset(st_: *mut aegis256x4_mac_state);
 
     fn aegis256x4_mac_state_clone(dst: *mut aegis256x4_mac_state, src: *const aegis256x4_mac_state);
+
+    fn aegis256x4_state_init(
+        st_: *mut aegis256x4_state,
+        ad: *const u8,
+        adlen: usize,
+        npub: *const u8,
+        k: *const u8,
+    );
+
+    fn aegis256x4_state_encrypt_update(
+        st_: *mut aegis256x4_state,
+        c: *mut u8,
+        m: *const u8,
+        mlen: usize,
+    ) -> c_int;
+
+    fn aegis256x4_state_encrypt_final(
+        st_: *mut aegis256x4_state,
+        mac: *mut u8,
+        maclen: usize,
+    ) -> c_int;
+
+    fn aegis256x4_state_decrypt_update(
+        st_: *mut aegis256x4_state,
+        m: *mut u8,
+        c: *const u8,
+        clen: usize,
+    ) -> c_int;
+
+    fn aegis256x4_state_decrypt_final(
+        st_: *mut aegis256x4_state,
+        mac: *const u8,
+        maclen: usize,
+    ) -> c_int;
 }
 
 #[cfg(feature = "std")]
@@ -368,5 +402,96 @@ impl<const TAG_BYTES: usize> Aegis256X4Mac<TAG_BYTES> {
         unsafe {
             aegis256x4_mac_reset(&mut self.st);
         }
+    }
+}
+
+/// AEGIS-256X4 state for incremental encryption or decryption.
+#[derive(Debug)]
+pub struct Aegis256X4State<const TAG_BYTES: usize> {
+    st: aegis256x4_state,
+}
+
+impl<const TAG_BYTES: usize> Aegis256X4State<TAG_BYTES> {
+    fn ensure_init() {
+        #[cfg(feature = "std")]
+        INIT.call_once(|| assert_eq!(unsafe { aegis_init() }, 0));
+
+        #[cfg(not(feature = "std"))]
+        {
+            use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+            if INITIALIZED.load(Acquire) {
+                return;
+            }
+            let initializing = match INITIALIZING.compare_exchange(false, true, Acquire, Relaxed) {
+                Ok(initializing) => initializing,
+                Err(initializing) => initializing,
+            };
+            if initializing {
+                while !INITIALIZED.load(Acquire) {}
+            } else {
+                assert_eq!(unsafe { aegis_init() }, 0);
+                INITIALIZED.store(true, Release);
+                INITIALIZING.store(false, Release);
+            }
+        }
+    }
+
+    /// Initializes the state for incremental encryption or decryption.
+    ///
+    /// # Panics
+    /// Panics if `TAG_BYTES` is not 16 or 32.
+    pub fn new(key: &Key, nonce: &Nonce, ad: &[u8]) -> Self {
+        assert!(
+            TAG_BYTES == 16 || TAG_BYTES == 32,
+            "Invalid tag length, must be 16 or 32"
+        );
+        Self::ensure_init();
+        let mut st = aegis256x4_state { opaque: [0u8; 576] };
+        unsafe {
+            aegis256x4_state_init(&mut st, ad.as_ptr(), ad.len(), nonce.as_ptr(), key.as_ptr());
+        }
+        Aegis256X4State { st }
+    }
+
+    /// Encrypts a chunk. `c` must be at least `m.len()` bytes.
+    pub fn encrypt_update(&mut self, c: &mut [u8], m: &[u8]) -> Result<(), Error> {
+        if c.len() < m.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis256x4_state_encrypt_update(&mut self.st, c.as_mut_ptr(), m.as_ptr(), m.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Finalizes encryption and returns the authentication tag.
+    pub fn encrypt_final(mut self) -> Tag<TAG_BYTES> {
+        let mut tag = [0u8; TAG_BYTES];
+        unsafe {
+            aegis256x4_state_encrypt_final(&mut self.st, tag.as_mut_ptr(), TAG_BYTES);
+        }
+        tag
+    }
+
+    /// Decrypts a chunk. `m` must be at least `c.len()` bytes.
+    ///
+    /// The decrypted output must not be used until `decrypt_final` returns `Ok`.
+    pub fn decrypt_update(&mut self, m: &mut [u8], c: &[u8]) -> Result<(), Error> {
+        if m.len() < c.len() {
+            return Err(Error::InvalidLength);
+        }
+        let ret = unsafe {
+            aegis256x4_state_decrypt_update(&mut self.st, m.as_mut_ptr(), c.as_ptr(), c.len())
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
+    }
+
+    /// Verifies the authentication tag and finalizes decryption.
+    pub fn decrypt_final(mut self, mac: &Tag<TAG_BYTES>) -> Result<(), Error> {
+        let ret = unsafe {
+            aegis256x4_state_decrypt_final(&mut self.st, mac.as_ptr(), TAG_BYTES)
+        };
+        if ret != 0 { Err(Error::InvalidTag) } else { Ok(()) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub enum Error {
     /// The authentication tag did not match: the ciphertext or associated data
     /// has been altered, or the wrong key or nonce was used.
     InvalidTag,
+    /// An output buffer was too short to hold the result.
+    InvalidLength,
 }
 
 #[cfg(feature = "std")]
@@ -35,6 +37,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::InvalidTag => write!(f, "Invalid tag"),
+            Error::InvalidLength => write!(f, "Invalid length"),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -440,6 +440,420 @@ mod test_vectors {
 
     #[test]
     #[cfg(feature = "std")]
+    fn test_aegis128l_state_vectors() {
+        use crate::aegis128l::Aegis128LState;
+
+        let data = fs::read_to_string("src/test-vectors/aegis-128l-test-vectors.json")
+            .expect("Unable to read test vectors");
+        let vectors: Vec<Value> =
+            serde_json::from_str(&data).expect("Unable to parse test vectors");
+
+        for vector in vectors.iter() {
+            if vector.get("key").is_none()
+                || vector.get("ct").is_none()
+                || vector.get("msg").is_none()
+                || vector.get("ad").is_none()
+                || vector.get("tag128").is_none()
+            {
+                continue;
+            }
+
+            let name = vector["name"].as_str().unwrap();
+            let key_vec = Hex::decode_to_vec(vector["key"].as_str().unwrap(), None).unwrap();
+            let nonce_vec = Hex::decode_to_vec(vector["nonce"].as_str().unwrap(), None).unwrap();
+            let key: [u8; 16] = key_vec.try_into().expect("Invalid key length");
+            let nonce: [u8; 16] = nonce_vec.try_into().expect("Invalid nonce length");
+            let ad = Hex::decode_to_vec(vector["ad"].as_str().unwrap(), None).unwrap();
+            let msg = Hex::decode_to_vec(vector["msg"].as_str().unwrap(), None).unwrap();
+            let expected_ct = Hex::decode_to_vec(vector["ct"].as_str().unwrap(), None).unwrap();
+            let expected_tag128 =
+                Hex::decode_to_vec(vector["tag128"].as_str().unwrap(), None).unwrap();
+            let expected_tag256 =
+                Hex::decode_to_vec(vector["tag256"].as_str().unwrap(), None).unwrap();
+
+            // Test with 128-bit tag
+            {
+                let mut st = Aegis128LState::<16>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag128[..], "Test {} failed: tag128 mismatch", name);
+
+                let mut st = Aegis128LState::<16>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+
+            // Test with 256-bit tag
+            {
+                let mut st = Aegis128LState::<32>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag256[..], "Test {} failed: tag256 mismatch", name);
+
+                let mut st = Aegis128LState::<32>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_aegis128x2_state_vectors() {
+        use crate::aegis128x2::Aegis128X2State;
+
+        let data = fs::read_to_string("src/test-vectors/aegis-128x2-test-vectors.json")
+            .expect("Unable to read test vectors");
+        let vectors: Vec<Value> =
+            serde_json::from_str(&data).expect("Unable to parse test vectors");
+
+        for vector in vectors.iter() {
+            if vector.get("key").is_none()
+                || vector.get("ct").is_none()
+                || vector.get("msg").is_none()
+                || vector.get("ad").is_none()
+                || vector.get("tag128").is_none()
+            {
+                continue;
+            }
+
+            let name = vector["name"].as_str().unwrap();
+            let key_vec = Hex::decode_to_vec(vector["key"].as_str().unwrap(), None).unwrap();
+            let nonce_vec = Hex::decode_to_vec(vector["nonce"].as_str().unwrap(), None).unwrap();
+            let key: [u8; 16] = key_vec.try_into().expect("Invalid key length");
+            let nonce: [u8; 16] = nonce_vec.try_into().expect("Invalid nonce length");
+            let ad = Hex::decode_to_vec(vector["ad"].as_str().unwrap(), None).unwrap();
+            let msg = Hex::decode_to_vec(vector["msg"].as_str().unwrap(), None).unwrap();
+            let expected_ct = Hex::decode_to_vec(vector["ct"].as_str().unwrap(), None).unwrap();
+            let expected_tag128 =
+                Hex::decode_to_vec(vector["tag128"].as_str().unwrap(), None).unwrap();
+            let expected_tag256 =
+                Hex::decode_to_vec(vector["tag256"].as_str().unwrap(), None).unwrap();
+
+            // Test with 128-bit tag
+            {
+                let mut st = Aegis128X2State::<16>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag128[..], "Test {} failed: tag128 mismatch", name);
+
+                let mut st = Aegis128X2State::<16>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+
+            // Test with 256-bit tag
+            {
+                let mut st = Aegis128X2State::<32>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag256[..], "Test {} failed: tag256 mismatch", name);
+
+                let mut st = Aegis128X2State::<32>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_aegis128x4_state_vectors() {
+        use crate::aegis128x4::Aegis128X4State;
+
+        let data = fs::read_to_string("src/test-vectors/aegis-128x4-test-vectors.json")
+            .expect("Unable to read test vectors");
+        let vectors: Vec<Value> =
+            serde_json::from_str(&data).expect("Unable to parse test vectors");
+
+        for vector in vectors.iter() {
+            if vector.get("key").is_none()
+                || vector.get("ct").is_none()
+                || vector.get("msg").is_none()
+                || vector.get("ad").is_none()
+                || vector.get("tag128").is_none()
+            {
+                continue;
+            }
+
+            let name = vector["name"].as_str().unwrap();
+            let key_vec = Hex::decode_to_vec(vector["key"].as_str().unwrap(), None).unwrap();
+            let nonce_vec = Hex::decode_to_vec(vector["nonce"].as_str().unwrap(), None).unwrap();
+            let key: [u8; 16] = key_vec.try_into().expect("Invalid key length");
+            let nonce: [u8; 16] = nonce_vec.try_into().expect("Invalid nonce length");
+            let ad = Hex::decode_to_vec(vector["ad"].as_str().unwrap(), None).unwrap();
+            let msg = Hex::decode_to_vec(vector["msg"].as_str().unwrap(), None).unwrap();
+            let expected_ct = Hex::decode_to_vec(vector["ct"].as_str().unwrap(), None).unwrap();
+            let expected_tag128 =
+                Hex::decode_to_vec(vector["tag128"].as_str().unwrap(), None).unwrap();
+            let expected_tag256 =
+                Hex::decode_to_vec(vector["tag256"].as_str().unwrap(), None).unwrap();
+
+            // Test with 128-bit tag
+            {
+                let mut st = Aegis128X4State::<16>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag128[..], "Test {} failed: tag128 mismatch", name);
+
+                let mut st = Aegis128X4State::<16>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+
+            // Test with 256-bit tag
+            {
+                let mut st = Aegis128X4State::<32>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag256[..], "Test {} failed: tag256 mismatch", name);
+
+                let mut st = Aegis128X4State::<32>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_aegis256_state_vectors() {
+        use crate::aegis256::Aegis256State;
+
+        let data = fs::read_to_string("src/test-vectors/aegis-256-test-vectors.json")
+            .expect("Unable to read test vectors");
+        let vectors: Vec<Value> =
+            serde_json::from_str(&data).expect("Unable to parse test vectors");
+
+        for vector in vectors.iter() {
+            if vector.get("key").is_none()
+                || vector.get("ct").is_none()
+                || vector.get("msg").is_none()
+                || vector.get("ad").is_none()
+                || vector.get("tag128").is_none()
+            {
+                continue;
+            }
+
+            let name = vector["name"].as_str().unwrap();
+            let key_vec = Hex::decode_to_vec(vector["key"].as_str().unwrap(), None).unwrap();
+            let nonce_vec = Hex::decode_to_vec(vector["nonce"].as_str().unwrap(), None).unwrap();
+            let key: [u8; 32] = key_vec.try_into().expect("Invalid key length");
+            let nonce: [u8; 32] = nonce_vec.try_into().expect("Invalid nonce length");
+            let ad = Hex::decode_to_vec(vector["ad"].as_str().unwrap(), None).unwrap();
+            let msg = Hex::decode_to_vec(vector["msg"].as_str().unwrap(), None).unwrap();
+            let expected_ct = Hex::decode_to_vec(vector["ct"].as_str().unwrap(), None).unwrap();
+            let expected_tag128 =
+                Hex::decode_to_vec(vector["tag128"].as_str().unwrap(), None).unwrap();
+            let expected_tag256 =
+                Hex::decode_to_vec(vector["tag256"].as_str().unwrap(), None).unwrap();
+
+            // Test with 128-bit tag
+            {
+                let mut st = Aegis256State::<16>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag128[..], "Test {} failed: tag128 mismatch", name);
+
+                let mut st = Aegis256State::<16>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+
+            // Test with 256-bit tag
+            {
+                let mut st = Aegis256State::<32>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag256[..], "Test {} failed: tag256 mismatch", name);
+
+                let mut st = Aegis256State::<32>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_aegis256x2_state_vectors() {
+        use crate::aegis256x2::Aegis256X2State;
+
+        let data = fs::read_to_string("src/test-vectors/aegis-256x2-test-vectors.json")
+            .expect("Unable to read test vectors");
+        let vectors: Vec<Value> =
+            serde_json::from_str(&data).expect("Unable to parse test vectors");
+
+        for vector in vectors.iter() {
+            if vector.get("key").is_none()
+                || vector.get("ct").is_none()
+                || vector.get("msg").is_none()
+                || vector.get("ad").is_none()
+                || vector.get("tag128").is_none()
+            {
+                continue;
+            }
+
+            let name = vector["name"].as_str().unwrap();
+            let key_vec = Hex::decode_to_vec(vector["key"].as_str().unwrap(), None).unwrap();
+            let nonce_vec = Hex::decode_to_vec(vector["nonce"].as_str().unwrap(), None).unwrap();
+            let key: [u8; 32] = key_vec.try_into().expect("Invalid key length");
+            let nonce: [u8; 32] = nonce_vec.try_into().expect("Invalid nonce length");
+            let ad = Hex::decode_to_vec(vector["ad"].as_str().unwrap(), None).unwrap();
+            let msg = Hex::decode_to_vec(vector["msg"].as_str().unwrap(), None).unwrap();
+            let expected_ct = Hex::decode_to_vec(vector["ct"].as_str().unwrap(), None).unwrap();
+            let expected_tag128 =
+                Hex::decode_to_vec(vector["tag128"].as_str().unwrap(), None).unwrap();
+            let expected_tag256 =
+                Hex::decode_to_vec(vector["tag256"].as_str().unwrap(), None).unwrap();
+
+            // Test with 128-bit tag
+            {
+                let mut st = Aegis256X2State::<16>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag128[..], "Test {} failed: tag128 mismatch", name);
+
+                let mut st = Aegis256X2State::<16>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+
+            // Test with 256-bit tag
+            {
+                let mut st = Aegis256X2State::<32>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag256[..], "Test {} failed: tag256 mismatch", name);
+
+                let mut st = Aegis256X2State::<32>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_aegis256x4_state_vectors() {
+        use crate::aegis256x4::Aegis256X4State;
+
+        let data = fs::read_to_string("src/test-vectors/aegis-256x4-test-vectors.json")
+            .expect("Unable to read test vectors");
+        let vectors: Vec<Value> =
+            serde_json::from_str(&data).expect("Unable to parse test vectors");
+
+        for vector in vectors.iter() {
+            if vector.get("key").is_none()
+                || vector.get("ct").is_none()
+                || vector.get("msg").is_none()
+                || vector.get("ad").is_none()
+                || vector.get("tag128").is_none()
+            {
+                continue;
+            }
+
+            let name = vector["name"].as_str().unwrap();
+            let key_vec = Hex::decode_to_vec(vector["key"].as_str().unwrap(), None).unwrap();
+            let nonce_vec = Hex::decode_to_vec(vector["nonce"].as_str().unwrap(), None).unwrap();
+            let key: [u8; 32] = key_vec.try_into().expect("Invalid key length");
+            let nonce: [u8; 32] = nonce_vec.try_into().expect("Invalid nonce length");
+            let ad = Hex::decode_to_vec(vector["ad"].as_str().unwrap(), None).unwrap();
+            let msg = Hex::decode_to_vec(vector["msg"].as_str().unwrap(), None).unwrap();
+            let expected_ct = Hex::decode_to_vec(vector["ct"].as_str().unwrap(), None).unwrap();
+            let expected_tag128 =
+                Hex::decode_to_vec(vector["tag128"].as_str().unwrap(), None).unwrap();
+            let expected_tag256 =
+                Hex::decode_to_vec(vector["tag256"].as_str().unwrap(), None).unwrap();
+
+            // Test with 128-bit tag
+            {
+                let mut st = Aegis256X4State::<16>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag128[..], "Test {} failed: tag128 mismatch", name);
+
+                let mut st = Aegis256X4State::<16>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+
+            // Test with 256-bit tag
+            {
+                let mut st = Aegis256X4State::<32>::new(&key, &nonce, &ad);
+                let mut ct = vec![0u8; msg.len()];
+                st.encrypt_update(&mut ct, &msg).unwrap();
+                let tag = st.encrypt_final();
+                assert_eq!(ct, expected_ct, "Test {} failed: ciphertext mismatch", name);
+                assert_eq!(&tag[..], &expected_tag256[..], "Test {} failed: tag256 mismatch", name);
+
+                let mut st = Aegis256X4State::<32>::new(&key, &nonce, &ad);
+                let mut decrypted = vec![0u8; ct.len()];
+                st.decrypt_update(&mut decrypted, &ct).unwrap();
+                st.decrypt_final(&tag)
+                    .unwrap_or_else(|_| panic!("Decryption failed for test {}", name));
+                assert_eq!(decrypted, msg, "Test {} failed: decryption mismatch", name);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
     fn test_aegismac_vectors() {
         use crate::aegis128l::Aegis128LMac;
         use crate::aegis128x2::Aegis128X2Mac;


### PR DESCRIPTION
## Add incremental encryption/decryption API (`Aegis*State`)

  Exposes the libaegis streaming encrypt/decrypt API through a safe Rust interface for all six AEGIS variants:
  AEGIS-128L, AEGIS-128X2, AEGIS-128X4, AEGIS-256, AEGIS-256X2, and AEGIS-256X4.

  ### Changes

  **`src/lib.rs`** — adds `Error::InvalidLength` for callers that pass an undersized output buffer.

  **`src/c/aegis*.rs`** — for each variant:
  - Adds `extern "C"` declarations for the five incremental C functions: `aegis*_state_init`,
  `aegis*_state_encrypt_update`, `aegis*_state_encrypt_final`, `aegis*_state_decrypt_update`,
  `aegis*_state_decrypt_final`.
  - Adds a new `pub struct Aegis*State<const TAG_BYTES: usize>` that wraps the private C state type (inheriting its
  `repr(C)` and alignment). `new(key, nonce, ad)` zeroes the opaque state and calls `state_init`. The four streaming
  methods map directly to their C counterparts:
    - `encrypt_update(&mut self, c, m)` — returns `Err(InvalidLength)` if `c.len() < m.len()`
    - `encrypt_final(self)` — consumes the state, returns `Tag<TAG_BYTES>`
    - `decrypt_update(&mut self, m, c)` — returns `Err(InvalidLength)` if `m.len() < c.len()`
    - `decrypt_final(self, mac)` — consumes the state, verifies the tag, returns `Result<(), Error>`

  **`src/tests.rs`** — adds one test per variant (`test_aegis*_state_vectors`) that drives the streaming API against the
  existing JSON test vectors, asserting ciphertext and tag match the one-shot API for both 128-bit and 256-bit tags.

  ### Test plan

  - `cargo test --features std` — all 18 tests pass, including the 6 new `*_state_vectors` tests